### PR TITLE
fix for bright themes on iterm

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (output) {
       ':',
       lineNumber
     ].join('')
-    console.log(`${chalk.white.underline(lineHeading)}`)
+    console.log(`${chalk.red.underline(lineHeading)}`)
 
     var messages = error.message
     // Merge 'Comment' into 'Blame' to reproduce default flow output
@@ -44,8 +44,8 @@ module.exports = function (output) {
       }).join('')
 
       const descr = `${whitespace(message.start)}${carets(message.start, message.end)} ${message.descr}`
-      console.log(`  ${chalk.white.bold(lineNumber + ':')} ${context}`)
-      console.log(chalk.white.bold(`    ${descr}`))
+      console.log(`  ${chalk.red.bold(lineNumber + ':')} ${context}`)
+      console.log(chalk.red.bold(`    ${descr}`))
     })
   })
 }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function (output) {
       }).join('')
 
       const descr = `${whitespace(message.start)}${carets(message.start, message.end)} ${message.descr}`
-      console.log(`  ${chalk.red.bold(lineNumber + ':')} ${context}`)
+      console.log(` ${chalk.red.bold(lineNumber + ':')} ${context}`)
       console.log(chalk.red.bold(`    ${descr}`))
     })
   })


### PR DESCRIPTION
- change color to red https://github.com/charliedowler/gulp-flowtype/issues/47
- remove extra space
